### PR TITLE
Support for different rain datarefs

### DIFF
--- a/src/librain.c
+++ b/src/librain.c
@@ -1186,6 +1186,20 @@ bool_t
 librain_init(const char *the_shaderpath, const librain_glass_t *glass,
     size_t num)
 {
+	librain_opt_t opts = {
+		.rain_dataref_index = 0
+	};
+	return librain_init_opt(the_shaderpath, glass, num, opts);
+}
+
+/*
+ * Initializes librain for operation specifying the options. This MUST
+ * be called at plugin load time.
+ */
+bool_t
+librain_init_opt(const char *the_shaderpath, const librain_glass_t *glass,
+    size_t num, const librain_opt_t opt)
+{
 	ASSERT(the_shaderpath != NULL);
 	ASSERT(glass != NULL);
 	ASSERT(num != 0);
@@ -1206,8 +1220,13 @@ librain_init(const char *the_shaderpath, const librain_glass_t *glass,
 	fdr_find(&drs.proj_matrix, "sim/graphics/view/projection_matrix");
 	fdr_find(&drs.acf_matrix, "sim/graphics/view/acf_matrix");
 	fdr_find(&drs.viewport, "sim/graphics/view/viewport");
-	fdr_find(&drs.precip_rat,
+	if (opt.rain_dataref_index == 0) {
+		fdr_find(&drs.precip_rat,
 	    "sim/weather/precipitation_on_aircraft_ratio");
+	}
+	else {
+		fdr_find(&drs.precip_rat, "sim/weather/rain_percent");
+	}
 	fdr_find(&drs.prop_thrust, "sim/flightmodel/engine/POINT_thrust");
 	fdr_find(&drs.hdg, "sim/flightmodel/position/psi");
 	fdr_find(&drs.beta, "sim/flightmodel/position/beta");

--- a/src/librain.h
+++ b/src/librain.h
@@ -423,11 +423,25 @@ typedef struct {
 	double		wiper_radius_inner[MAX_WIPERS];
 } librain_glass_t;
 
+typedef struct {
+	/*
+	 * Switch between xp6+ or xp10+ rain dataref
+	 * 0 to use sim/weather/precipitation_on_aircraft_ratio
+	 * 1 to use sim/weather/rain_percent
+	 * 
+	 * New datarefs could be targeted in future releases
+	 */
+	int rain_dataref_index;
+} librain_opt_t;
+
 /*
  * Initialization & teardown functions. See librain.c for more information.
  */
 LIBRAIN_EXPORT bool_t librain_init(const char *the_shaderpath,
     const librain_glass_t *glass, size_t num);
+LIBRAIN_EXPORT bool_t librain_init_opt(const char *the_shaderpath,
+    const librain_glass_t *glass, size_t num,
+	const librain_opt_t options);
 LIBRAIN_EXPORT void librain_fini(void);
 
 /*


### PR DESCRIPTION
Some X-Plane plugins, such XEnviro, use sim/weather/rain_percent instead of sim/weather/precipitation_on_aircraft_ratio.
Directly providing the dataref as const char* via parameter/struct was not possible as fdr_find only accept literals. Moreover, the datarerf must be a ratio.

* A new librain_init_opt export has been added
* Using the librain_opt_t struct it is now possible to switch the rain dataref in use
* Ability to support more rain datarefs in the future
* librain_init works like before; no compatibility issues are expected with present implementations